### PR TITLE
Added CocoaPods pod spec for version 0.0.1

### DIFF
--- a/AGi18n.podspec
+++ b/AGi18n.podspec
@@ -1,0 +1,18 @@
+#
+# Be sure to run 'pod spec lint AGi18n.podspec' to ensure this is a
+# valid spec.
+#
+Pod::Spec.new do |s|
+  s.name                  = "AGi18n"
+  s.version               = "0.0.1"
+  s.summary               = "Localize iOS apps by automatically extracting texts from code and XIB files and inject them back on runtime."
+  s.description           = "Utility to easily localize your iOS apps by automatically extracting texts from code and XIB files into a Localizable strings and inject them back on runtime without changing your XIB files."
+  s.homepage              = "https://github.com/angelolloqui/AGi18n"
+  s.license               = "MIT License"
+  s.author                = { "Angel Garcia Olloqui" => "http://angelolloqui.com" }
+  s.source                = { :git => "https://github.com/angelolloqui/AGi18n.git", :tag => "0.0.1" }
+  s.platform              = :ios, '5.0'
+  s.ios.deployment_target = '5.0'
+  s.source_files          = 'lib/*.{h,m}'
+  s.requires_arc          = true
+end


### PR DESCRIPTION
This pod spec successfully passed linting with CocoaPods 0.17.1.

I added 5.0 as the minimum iOS platform which is basically an artificial restraint. It's more about which iOS versions you're planning to support with this library in the future.

I also enabled usage of ARC for the pod. After browsing quickly through the source code that wouldn't be needed as of now so it's more a matter of personal preference for future development.

Thanks for this project btw, nice work. :)
