### PR TITLE
Extract strings from nibs and storyboards as well

### DIFF
--- a/bin/agi18n
+++ b/bin/agi18n
@@ -65,8 +65,8 @@ languages.each do |dir|
  	`genstrings -a -littleEndian -o #{dir} "#{source_files.join('" "')}"`
  	
 	# Execute genxibstrings appending results	
-	puts "Executing `#{current_dir}/genxibstrings -a -o #{dir} **/*.xib`"	
-	source_files = Dir["**/*.xib"]
+	puts "Executing `#{current_dir}/genxibstrings -a -o #{dir} **/*.{xib,nib,storyboard}`"	
+	source_files = Dir["**/*.{xib,nib,storyboard}"]
  	`#{current_dir}/genxibstrings -a -o #{dir} "#{source_files.join('" "')}"`
  	
 	# Remove duplicates by order	

--- a/bin/genxibstrings
+++ b/bin/genxibstrings
@@ -26,7 +26,7 @@ loop {
 }
 
 output = File.join(output, 'Localizable.strings')
-input_files.push('**/*.xib') unless input_files.length > 0
+input_files.push('**/*.{xib,nib,storyboard}') unless input_files.length > 0
 
 puts "Output file: #{output}"
 puts "Input files: #{input_files}"


### PR DESCRIPTION
ibtools extracts strings from storyboards and nibs fine, so I don't see any reason to exclude them
