### PR TITLE
Fixes encoding compatibility, Xcode uses BOM

### DIFF
--- a/bin/agi18n
+++ b/bin/agi18n
@@ -16,8 +16,7 @@ def remove_duplicates(file)
 	comment = ""
 
 	# Parse all the labels from the xib
-	File.open(file, 'rb:UTF-16LE').each do |line|
-
+	File.open(file, 'rb:bom|UTF-16LE').each do |line|
 		# Read comments
 		md = COMMENTS_REGEXP.match(line)  
 		if md  then
@@ -38,6 +37,8 @@ def remove_duplicates(file)
 	end  
 
 	File.open(file, 'wb:UTF-16LE') do |file|	
+    file.puts "\uFEFF"
+    
 		labels.keys.sort.each do |key|
 			str = key.first
 			comment = labels[key][:comment]


### PR DESCRIPTION
Since Xcode/genstrings uses UTF16 with BOM, you need to read the output from genstrings with BOM, otherwise it will not correctly handle all the linebreaks.
Writing a BOM in the output is preferred as well, so you don't have to manually change things in Xcode
