### PR TITLE
Avoid ibtools trying to process nib/xib/storyboard for each file

### DIFF
--- a/bin/genxibstrings
+++ b/bin/genxibstrings
@@ -41,17 +41,19 @@ input_files.each do |files|
 		name = File.basename(file)
 		temp_file = File.join(Dir.tmpdir, name + ".strings")
 
-		# Extract labels
-		`ibtool --export-strings-file "#{temp_file}" "#{file}"`
+		if File.exists?(temp_file)  then
+			# Extract labels
+			`ibtool --export-strings-file "#{temp_file}" "#{file}"`
 
-		# Parse all the labels from the xib
-		File.open(temp_file, 'rb:UTF-16LE').each do |line|
-			md = LABEL_REGEXP.match(line)  
-			if md  then
-				key = md.captures			
-				labels[key] = Array.new() if labels[key].nil?
-				labels[key].push(name)
-			end 
+			# Parse all the labels from the xib
+			File.open(temp_file, 'rb:UTF-16LE').each do |line|
+				md = LABEL_REGEXP.match(line)  
+				if md  then
+					key = md.captures			
+					labels[key] = Array.new() if labels[key].nil?
+					labels[key].push(name)
+				end
+			end
 		end  	
 	end
 end


### PR DESCRIPTION
Without this was causing script to halt for me (Ruby 2.0.0p247) when trying to open a temp file that had not been generated.
Indirect cause of this problem is when support was added for nib/xib/storyboard, since now it attempts to generate strings files for all three file extensions, and then ibtools attempts to process them all as well. The problem occurs when it reaches File.open, trying to load strings files that ibtool failed to generate.
