### PR TITLE
Add once_token to NSObject+AGi18n +load method

### DIFF
--- a/lib/NSObject+AGi18n.m
+++ b/lib/NSObject+AGi18n.m
@@ -19,11 +19,14 @@
 #pragma mark - Method swizzling
 
 + (void)load {
-    Method awakeFromNibOriginal = class_getInstanceMethod(self, @selector(awakeFromNib));
-    Method awakeFromNibCustom = class_getInstanceMethod(self, @selector(awakeFromNibCustom));
-        
-    //Swizzle methods
-    method_exchangeImplementations(awakeFromNibOriginal, awakeFromNibCustom);
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        Method awakeFromNibOriginal = class_getInstanceMethod(self, @selector(awakeFromNib));
+        Method awakeFromNibCustom = class_getInstanceMethod(self, @selector(awakeFromNibCustom));
+
+        //Swizzle methods
+        method_exchangeImplementations(awakeFromNibOriginal, awakeFromNibCustom);
+    });
 }
 
 - (void)awakeFromNibCustom {


### PR DESCRIPTION
Add dispatch_once to +load to guarantee the swizzling only execute once, prevent some strange behavior or conflict when working with other libraries. (such as IQKeyboardManager)